### PR TITLE
Use dbExecute() where appropriate

### DIFF
--- a/tests/testthat/test-crashes.R
+++ b/tests/testthat/test-crashes.R
@@ -10,7 +10,7 @@ test_that("requeueing crashed consumers", {
 
   ## now we simulate a crash, so the connection embedded in `msg` is closed
   rm(msg)
-  gc()
+  suppressWarnings(gc())
 
   ## now, if we try to get a message, the same message must be served again
   msg <- try_consume(q)

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -20,7 +20,7 @@ test_that("db_query", {
   ensure_db(db)
   con <- dbConnect(SQLite(), db, synchronous = NULL)
   on.exit(dbDisconnect(con))
-  db_query(
+  db_execute(
     con, 'INSERT INTO ?table (name) VALUES (?value)',
     table = "meta", value = "foobar"
   )
@@ -36,7 +36,7 @@ test_that("db_execute", {
   ensure_db(db)
   con <- dbConnect(SQLite(), db, synchronous = NULL)
   on.exit(dbDisconnect(con))
-  db_query(
+  db_execute(
     con, 'INSERT INTO ?table (name) VALUES (?value)',
     table = "meta", value = "foobar"
   )
@@ -54,7 +54,7 @@ test_that("do_db", {
   db <- tempfile()
   on.exit(unlink(db))
   ensure_db(db)
-  do_db(
+  do_db_execute(
     db, 'INSERT INTO ?table (name) VALUES (?value)',
     table = "meta", value = "foobar"
   )


### PR DESCRIPTION
because dbGetQuery() now gives a warning if used on a statement.

I do wonder why the code uses SQL interpolation instead of the much more efficient parametrized queries.